### PR TITLE
起動時に adb devices を実行する

### DIFF
--- a/TransporterPad/Info.plist
+++ b/TransporterPad/Info.plist
@@ -22,9 +22,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.0</string>
+	<string>2.0.1</string>
 	<key>CFBundleVersion</key>
-	<string>200</string>
+	<string>201</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>

--- a/TransporterPad/Services/CommandExecutor/CommandExecutor.swift
+++ b/TransporterPad/Services/CommandExecutor/CommandExecutor.swift
@@ -134,4 +134,10 @@ extension CommandExecutor {
         }
         return CommandExecutor(environment: environment, launchPath: launchPath, arguments: arguments)
     }
+    
+    class func startAdbServerIfNeeded(environment: Environment) -> CommandExecutor {
+        let launchPath = environment.adbToolPath
+        let arguments = ["devices"]
+        return CommandExecutor(environment: environment, launchPath: launchPath, arguments: arguments)
+    }
 }

--- a/TransporterPad/Services/CommandExecutor/Transporter.swift
+++ b/TransporterPad/Services/CommandExecutor/Transporter.swift
@@ -30,6 +30,10 @@ class Transporter: NSObject {
         super.init()
     }
     
+    func setup() {
+        CommandExecutor.startAdbServerIfNeeded(environment: environment).run()
+    }
+    
     func transport(package: AppPackage, targetDevices: [Device], reInstall: Bool) {
         if working { return }
         let devices = targetDevices.filter { d in d.platform == package.platform }

--- a/TransporterPad/ViewModels/MainViewModel.swift
+++ b/TransporterPad/ViewModels/MainViewModel.swift
@@ -84,6 +84,7 @@ class MainViewModel: NSObject {
         deviceWatcher.delegate = self
         deviceWatcher.start()
         transporter.delegate = self
+        transporter.setup()
     }
     
     func startTransporter(reInstall: Bool) {


### PR DESCRIPTION
Android の開発環境がなく、デバイスの認証を通していない場合にデバイス一覧に表示されていなかった。

adb server がないのが原因なので、起動時に adb devices を実行しておく。